### PR TITLE
Fix: Helm namespace 동적 설정 및 Service selector component 분리

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,8 +323,8 @@ jobs:
         run: |
           VERSION="${{ env.RELEASE_TAG }}"
           VERSION_NO_V="${VERSION#v}"
-          cd deploy/terraform
-          tar -czf "realtime-svg-terraform-${VERSION_NO_V}.tar.gz" realtime-svg/
+          cd deploy/terraform/realtime-svg
+          tar -czf "../realtime-svg-terraform-${VERSION_NO_V}.tar.gz" .
 
       - name: Upload Terraform module to release
         env:

--- a/deploy/helm/realtime-svg/templates/configmap.yaml
+++ b/deploy/helm/realtime-svg/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "realtime-svg.fullname" . }}-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
 data:

--- a/deploy/helm/realtime-svg/templates/deployment.yaml
+++ b/deploy/helm/realtime-svg/templates/deployment.yaml
@@ -2,9 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "realtime-svg.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -15,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "realtime-svg.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
   template:
     metadata:
       annotations:
@@ -25,6 +27,7 @@ spec:
         {{- end }}
       labels:
         {{- include "realtime-svg.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
     spec:
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/deploy/helm/realtime-svg/templates/ingress.yaml
+++ b/deploy/helm/realtime-svg/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "realtime-svg.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/deploy/helm/realtime-svg/templates/redis-deployment.yaml
+++ b/deploy/helm/realtime-svg/templates/redis-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "realtime-svg.fullname" . }}-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis

--- a/deploy/helm/realtime-svg/templates/redis-service.yaml
+++ b/deploy/helm/realtime-svg/templates/redis-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "realtime-svg.fullname" . }}-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis

--- a/deploy/helm/realtime-svg/templates/secret.yaml
+++ b/deploy/helm/realtime-svg/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "realtime-svg.fullname" . }}-secret
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
 type: Opaque

--- a/deploy/helm/realtime-svg/templates/service.yaml
+++ b/deploy/helm/realtime-svg/templates/service.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "realtime-svg.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "realtime-svg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
 spec:
   type: {{ .Values.service.type }}
   {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
@@ -23,3 +24,4 @@ spec:
   {{- end }}
   selector:
     {{- include "realtime-svg.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend

--- a/deploy/helm/realtime-svg/values.yaml
+++ b/deploy/helm/realtime-svg/values.yaml
@@ -2,9 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Kubernetes namespace
-namespace: default
-
 # Container image configuration
 image:
   repository: ghcr.io/egoavara/realtime-svg

--- a/deploy/kubernetes/realtime-svg/install.yaml
+++ b/deploy/kubernetes/realtime-svg/install.yaml
@@ -113,6 +113,7 @@ metadata:
     app.kubernetes.io/name: realtime-svg
     app.kubernetes.io/instance: realtime-svg
     app.kubernetes.io/version: v0.1.4
+    app.kubernetes.io/component: backend
 spec:
   replicas: 2
   strategy:
@@ -124,12 +125,14 @@ spec:
     matchLabels:
       app.kubernetes.io/name: realtime-svg
       app.kubernetes.io/instance: realtime-svg
+      app.kubernetes.io/component: backend
   template:
     metadata:
       labels:
         app.kubernetes.io/name: realtime-svg
         app.kubernetes.io/instance: realtime-svg
         app.kubernetes.io/version: v0.1.4
+        app.kubernetes.io/component: backend
     spec:
       containers:
       - name: realtime-svg
@@ -190,11 +193,13 @@ metadata:
     app.kubernetes.io/name: realtime-svg
     app.kubernetes.io/instance: realtime-svg
     app.kubernetes.io/version: v0.1.4
+    app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: realtime-svg
     app.kubernetes.io/instance: realtime-svg
+    app.kubernetes.io/component: backend
   ports:
   - name: http
     port: 80

--- a/deploy/pulumi/realtime-svg/index.ts
+++ b/deploy/pulumi/realtime-svg/index.ts
@@ -78,6 +78,16 @@ export class RealtimeSvg extends pulumi.ComponentResource {
             "app.kubernetes.io/managed-by": "pulumi",
         };
 
+        const backendLabels = {
+            ...labels,
+            "app.kubernetes.io/component": "backend",
+        };
+
+        const redisLabels = {
+            ...labels,
+            "app.kubernetes.io/component": "redis",
+        };
+
         const redisUrl = pulumi.all([redisEnabled, redisPassword, redisExternalUrl]).apply(([enabled, password, externalUrl]) => 
             enabled 
                 ? (password 
@@ -113,7 +123,7 @@ export class RealtimeSvg extends pulumi.ComponentResource {
             metadata: {
                 name: appName,
                 namespace: namespace,
-                labels: labels,
+                labels: backendLabels,
             },
             spec: {
                 replicas: replicas,
@@ -128,11 +138,12 @@ export class RealtimeSvg extends pulumi.ComponentResource {
                     matchLabels: {
                         "app.kubernetes.io/name": appName,
                         "app.kubernetes.io/instance": appName,
+                        "app.kubernetes.io/component": "backend",
                     },
                 },
                 template: {
                     metadata: {
-                        labels: labels,
+                        labels: backendLabels,
                     },
                     spec: {
                         containers: [{
@@ -214,13 +225,14 @@ export class RealtimeSvg extends pulumi.ComponentResource {
             metadata: {
                 name: appName,
                 namespace: namespace,
-                labels: labels,
+                labels: backendLabels,
             },
             spec: {
                 type: serviceType,
                 selector: {
                     "app.kubernetes.io/name": appName,
                     "app.kubernetes.io/instance": appName,
+                    "app.kubernetes.io/component": "backend",
                 },
                 ports: [{
                     name: "http",
@@ -236,10 +248,7 @@ export class RealtimeSvg extends pulumi.ComponentResource {
                 metadata: {
                     name: `${appName}-redis`,
                     namespace: namespace,
-                    labels: {
-                        ...labels,
-                        "app.kubernetes.io/component": "redis",
-                    },
+                    labels: redisLabels,
                 },
                 spec: {
                     replicas: 1,
@@ -252,10 +261,7 @@ export class RealtimeSvg extends pulumi.ComponentResource {
                     },
                     template: {
                         metadata: {
-                            labels: {
-                                ...labels,
-                                "app.kubernetes.io/component": "redis",
-                            },
+                            labels: redisLabels,
                         },
                         spec: {
                             containers: [{
@@ -292,10 +298,7 @@ export class RealtimeSvg extends pulumi.ComponentResource {
                 metadata: {
                     name: `${appName}-redis`,
                     namespace: namespace,
-                    labels: {
-                        ...labels,
-                        "app.kubernetes.io/component": "redis",
-                    },
+                    labels: redisLabels,
                 },
                 spec: {
                     type: "ClusterIP",

--- a/deploy/terraform/realtime-svg/deployment.tf
+++ b/deploy/terraform/realtime-svg/deployment.tf
@@ -2,7 +2,7 @@ resource "kubernetes_deployment" "realtime_svg" {
   metadata {
     name      = local.app_name
     namespace = var.namespace
-    labels    = local.labels
+    labels    = local.backend_labels
   }
 
   spec {
@@ -18,14 +18,15 @@ resource "kubernetes_deployment" "realtime_svg" {
 
     selector {
       match_labels = {
-        "app.kubernetes.io/name"     = local.app_name
-        "app.kubernetes.io/instance" = local.app_name
+        "app.kubernetes.io/name"      = local.app_name
+        "app.kubernetes.io/instance"  = local.app_name
+        "app.kubernetes.io/component" = "backend"
       }
     }
 
     template {
       metadata {
-        labels = local.labels
+        labels = local.backend_labels
         annotations = {
           "checksum/config" = sha256(jsonencode(kubernetes_config_map.realtime_svg.data))
           "checksum/secret" = sha256(jsonencode(kubernetes_secret.realtime_svg.data))
@@ -134,15 +135,16 @@ resource "kubernetes_service" "realtime_svg" {
   metadata {
     name      = local.app_name
     namespace = var.namespace
-    labels    = local.labels
+    labels    = local.backend_labels
   }
 
   spec {
     type = var.service_type
 
     selector = {
-      "app.kubernetes.io/name"     = local.app_name
-      "app.kubernetes.io/instance" = local.app_name
+      "app.kubernetes.io/name"      = local.app_name
+      "app.kubernetes.io/instance"  = local.app_name
+      "app.kubernetes.io/component" = "backend"
     }
 
     port {

--- a/deploy/terraform/realtime-svg/main.tf
+++ b/deploy/terraform/realtime-svg/main.tf
@@ -9,6 +9,20 @@ locals {
     },
     var.labels
   )
+  
+  backend_labels = merge(
+    local.labels,
+    {
+      "app.kubernetes.io/component" = "backend"
+    }
+  )
+  
+  redis_labels = merge(
+    local.labels,
+    {
+      "app.kubernetes.io/component" = "redis"
+    }
+  )
 
   redis_url = var.redis_enabled ? (
     var.redis_password != "" ?

--- a/deploy/terraform/realtime-svg/redis.tf
+++ b/deploy/terraform/realtime-svg/redis.tf
@@ -4,12 +4,7 @@ resource "kubernetes_deployment" "redis" {
   metadata {
     name      = "${local.app_name}-redis"
     namespace = var.namespace
-    labels = merge(
-      local.labels,
-      {
-        "app.kubernetes.io/component" = "redis"
-      }
-    )
+    labels    = local.redis_labels
   }
 
   spec {
@@ -25,12 +20,7 @@ resource "kubernetes_deployment" "redis" {
 
     template {
       metadata {
-        labels = merge(
-          local.labels,
-          {
-            "app.kubernetes.io/component" = "redis"
-          }
-        )
+        labels = local.redis_labels
       }
 
       spec {
@@ -125,12 +115,7 @@ resource "kubernetes_service" "redis" {
   metadata {
     name      = "${local.app_name}-redis"
     namespace = var.namespace
-    labels = merge(
-      local.labels,
-      {
-        "app.kubernetes.io/component" = "redis"
-      }
-    )
+    labels    = local.redis_labels
   }
 
   spec {


### PR DESCRIPTION
## Summary

- Helm 차트의 namespace를 동적으로 설정하여 `--namespace` 플래그가 제대로 작동하도록 수정
- Backend/Redis Pod을 명확히 구분하기 위해 `app.kubernetes.io/component` 라벨 추가 및 Service selector에 반영
- Terraform 패키지 압축 시 불필요한 디렉토리 래핑 제거

## 변경 사항

### 1. Helm namespace 동적 설정
- 모든 템플릿에서 `{{ .Values.namespace }}` → `{{ .Release.Namespace }}` 변경
- `values.yaml`에서 불필요한 `namespace: default` 필드 제거
- 이제 `helm install --namespace my-namespace`가 의도대로 작동

### 2. Service selector component 분리
**문제**: Redis와 Backend Pod이 동일한 `app.kubernetes.io/name`, `app.kubernetes.io/instance` 라벨을 가지고 있어, Service selector가 두 Pod 모두 매칭. 이로 인해 `kubectl port-forward service/realtime-svg`가 redis Pod을 선택하는 문제 발생.

**해결**:
- Backend deployment/service에 `app.kubernetes.io/component: backend` 라벨 추가
- Redis deployment/service는 기존 `app.kubernetes.io/component: redis` 유지
- 모든 Service selector에 component 라벨 포함

적용 대상:
- Helm (`deploy/helm/realtime-svg/`)
- Terraform (`deploy/terraform/realtime-svg/`)
- Pulumi (`deploy/pulumi/realtime-svg/`)
- Kubernetes manifests (`deploy/kubernetes/realtime-svg/`)

### 3. Terraform 패키지 압축 개선
- 기존: `tar -czf ... realtime-svg/` → tarball 내부에 `realtime-svg/` 디렉토리 포함
- 변경: `cd realtime-svg && tar -czf ... .` → tarball 루트에 직접 `.tf` 파일 배치
- 이제 `source = "https://github.com/.../realtime-svg-terraform-0.1.5.tar.gz"` 형태로 바로 사용 가능

## 테스트 방법

```bash
# Helm: 다른 namespace에 설치 테스트
helm install my-release deploy/helm/realtime-svg --namespace test-ns --create-namespace

# Service selector 확인
kubectl get pods -n test-ns -l app.kubernetes.io/component=backend
kubectl get pods -n test-ns -l app.kubernetes.io/component=redis

# Port-forward가 backend pod을 선택하는지 확인
kubectl port-forward -n test-ns service/realtime-svg 8080:80
```